### PR TITLE
Update adyen notification compatibility

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -45,7 +45,7 @@ class AdyenNotification < ActiveRecord::Base
   # Auth will have no original reference, all successive notifications with
   # reference the first auth notification
   has_many :next,
-    class_name: self,
+    class_name: 'AdyenNotification',
     foreign_key: :original_reference,
     primary_key: :psp_reference,
     inverse_of: :prev

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -37,7 +37,7 @@ class AdyenNotification < ActiveRecord::Base
   REFUNDED_REVERSED = "REFUNDED_REVERSED".freeze
 
   belongs_to :prev,
-    class_name: self,
+    class_name: 'AdyenNotification',
     foreign_key: :original_reference,
     primary_key: :psp_reference,
     inverse_of: :next
@@ -51,7 +51,7 @@ class AdyenNotification < ActiveRecord::Base
     inverse_of: :prev
 
   belongs_to :order,
-    class_name: Spree::Order,
+    class_name: 'Spree::Order',
     primary_key: :number,
     foreign_key: :merchant_reference
 

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -2,7 +2,7 @@ module Spree
   module Adyen
     class RatepaySource < ::ActiveRecord::Base
       belongs_to :payment_method
-      belongs_to :user, class_name: user_class_name, foreign_key: "user_id"
+      belongs_to :user, class_name: 'Spree::User', foreign_key: "user_id"
       has_one :payment, class_name: "Spree::Payment", as: :source
       has_many :notifications,
         class_name: "AdyenNotification",
@@ -23,15 +23,6 @@ module Spree
       # @return [Bool] true if all DOB fields are set, false otherwise
       def has_dob?
         [dob_day, dob_month, dob_year].all?(&:present?)
-      end
-      
-      private
-      
-      # Returns user class as a string for association class name
-      #
-      # @return [String] The user class as a string.
-      def user_class_name
-        Spree.user_class.to_s
       end
     end
   end

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -2,7 +2,7 @@ module Spree
   module Adyen
     class RatepaySource < ::ActiveRecord::Base
       belongs_to :payment_method
-      belongs_to :user, class_name: Spree.user_class, foreign_key: "user_id"
+      belongs_to :user, class_name: user_class_name, foreign_key: "user_id"
       has_one :payment, class_name: "Spree::Payment", as: :source
       has_many :notifications,
         class_name: "AdyenNotification",
@@ -23,6 +23,15 @@ module Spree
       # @return [Bool] true if all DOB fields are set, false otherwise
       def has_dob?
         [dob_day, dob_month, dob_year].all?(&:present?)
+      end
+      
+      private
+      
+      # Returns user class as a string for association class name
+      #
+      # @return [String] The user class as a string.
+      def user_class_name
+        Spree.user_class.to_s
       end
     end
   end


### PR DESCRIPTION
Rails 5.2 introduces the following error:

```DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `belongs_to :order, class_name: 'Spree::Order'` (called from <class:AdyenNotification> at /Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bundler/gems/solidus-adyen-b2d432a97710/app/models/adyen_notification.rb:53)```

This commit fixes that