### PR TITLE
SOL-282: removes BigDecimal.new for Ruby 2.7 upgrade

### DIFF
--- a/app/assets/stylesheets/spree/backend/solidus-adyen/communication.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/communication.scss
@@ -98,18 +98,18 @@ $timestamp-fade: 0.25;
 }
 
 .adyen-comm-icon {
-  @include display(flex);
-  @include flex-direction(column);
-  @include justify-content(space-between);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   font-size: 30px;
 }
 
 .adyen-comm-body {
-  @include display(flex);
-  @include align-items(center);
+  display: flex;
+  align-items: center;
 
   .adyen-comm-sent & {
-    @include flex-direction(row-reverse);
+    flex-direction: row-reverse;
   }
 }
 

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -104,7 +104,7 @@ module Spree
     end
 
     def check_signature
-      unless ::Adyen::HPP::Signature.verify(response_params, @payment_method.shared_secret)
+      unless ::Adyen::HPP::Signature.verify(response_params.to_h, @payment_method.shared_secret)
         raise "Payment Method not found."
       end
     end

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -28,7 +28,7 @@ module Spree
       )
     end
 
-    def provider_class
+    def gateway_class
       ::Adyen::REST
     end
 

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Spree::Gateway::AdyenCreditCard do
   it { is_expected.to be_a(Spree::Gateway) }
 
-  describe 'provider_class' do
-    subject { described_class.new.provider_class }
+  describe 'gateway_class' do
+    subject { described_class.new.gateway_class }
 
     it { is_expected.to eq(Adyen::REST) }
   end


### PR DESCRIPTION
`BigDecimal.new` is deprecated in Ruby 2.6 with the warning `warning: BigDecimal.new is deprecated; use BigDecimal() method instead.` and removed in Ruby 2.7. In order to upgrade to Ruby 2.7.